### PR TITLE
Added support for BSD, Solus, and OpenSUSE.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -202,6 +202,27 @@ fn get_package_count_fedora() -> Result<String> {
     Ok(pkg)
 }
 
+fn get_package_count_bsd() -> Result<String> {
+    let bpkg = Command::new("pkg").arg("info").output().context(Pkgcount)?;
+    let pkgs = bytecount::count(&bpkg.stdout, b'\n');
+    let pkg = format!("{}", pkgs);
+    Ok(pkg)
+}
+
+fn get_package_count_solus() -> Result<String> {
+    let eopkg = Command::new("eopkg").arg("list-installed").output().context(Pkgcount)?;
+    let pkgs = bytecount::count(&eopkg.stdout, b'\n');
+    let pkg = format!("{}", pkgs);
+    Ok(pkg)
+}
+
+fn get_package_count_suse() -> Result<String> {
+    let rpm = Command::new("rpm").arg("-qa").output().context(Pkgcount)?;
+    let pkgs = bytecount::count(&rpm.stdout, b'\n');
+    let pkg = format!("{}", pkgs);
+    Ok(pkg)
+}
+
 fn get_package_count_pip() -> Result<String> {
     let pip = Command::new("pip").arg("list").output().context(Pkgcount)?;
     let pkgs = bytecount::count(&pip.stdout, b'\n');
@@ -347,7 +368,7 @@ fn main() {
                         .short("p")
                         .long("packages")
                         .value_name("PKG MNGR")
-                        .help("Turn total package count on. Accepted values are \"pacman\", \"apt\", \"xbps\", \"dnf\", and \"pip\".")
+                        .help("Turn total package count on. Accepted values are \"pacman\", \"apt\", \"xbps\", \"dnf\", \"pkg\", \"eopkg\", \"rpm\", and \"pip\".")
                         .takes_value(true))
                     .arg(Arg::with_name("music")
                         .short("m")
@@ -529,6 +550,21 @@ fn main() {
     } else if packages == Some("dnf") {
         match get_package_count_fedora() {
             Ok(pkg) => table = add_row(table, bold, caps, borders, "PACKAGES (DNF)", &pkg),
+            Err(e) => error!("{}", e),
+        }
+    } else if packages == Some("pkg") {
+        match get_package_count_bsd() {
+            Ok(pkg) => table = add_row(table, bold, caps, borders, "PACKAGES (PKG)", &pkg),
+            Err(e) => error!("{}", e),
+        }
+    } else if packages == Some("eopkg") {
+        match get_package_count_solus() {
+            Ok(pkg) => table = add_row(table, bold, caps, borders, "PACKAGES (EOPKG)", &pkg),
+            Err(e) => error!("{}", e),
+        }
+    } else if packages == Some("rpm") {
+        match get_package_count_suse() {
+            Ok(pkg) => table = add_row(table, bold, caps, borders, "PACKAGES (RPM)", &pkg),
             Err(e) => error!("{}", e),
         }
     } else if packages == Some("pip") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,9 @@ enum Error {
     Editor { source: env::VarError },
     #[snafu(display("Could not retrieve IP address: {}", source))]
     Reqwest { source: reqwest::Error },
-    #[snafu(display("Could not retrieve package count. Perhaps you input the wrong package manager?"))]
+    #[snafu(display(
+        "Could not retrieve package count. Perhaps you input the wrong package manager?"
+    ))]
     Pkgcount { source: io::Error },
     #[snafu(display("Could not run mpc"))]
     Mpc { source: io::Error },
@@ -174,7 +176,10 @@ fn get_ip_address() -> Result<String> {
 }
 
 fn get_package_count_arch_based() -> Result<String> {
-    let pacman = Command::new("pacman").arg("-Qq").output().context(Pkgcount)?;
+    let pacman = Command::new("pacman")
+        .arg("-Qq")
+        .output()
+        .context(Pkgcount)?;
     let pkgs = bytecount::count(&pacman.stdout, b'\n');
     let pkg = format!("{}", pkgs);
     Ok(pkg)
@@ -188,14 +193,21 @@ fn get_package_count_debian_based() -> Result<String> {
 }
 
 fn get_package_count_void() -> Result<String> {
-    let xbps = Command::new("xbps-query").arg("-l").output().context(Pkgcount)?;
+    let xbps = Command::new("xbps-query")
+        .arg("-l")
+        .output()
+        .context(Pkgcount)?;
     let pkgs = bytecount::count(&xbps.stdout, b'\n');
     let pkg = format!("{}", pkgs);
     Ok(pkg)
 }
 
 fn get_package_count_fedora() -> Result<String> {
-    let dnf = Command::new("dnf").arg("list").arg("--installed").output().context(Pkgcount)?;
+    let dnf = Command::new("dnf")
+        .arg("list")
+        .arg("--installed")
+        .output()
+        .context(Pkgcount)?;
     let pkgs = bytecount::count(&dnf.stdout, b'\n');
     let pkgs = pkgs - 1;
     let pkg = format!("{}", pkgs);
@@ -210,7 +222,10 @@ fn get_package_count_bsd() -> Result<String> {
 }
 
 fn get_package_count_solus() -> Result<String> {
-    let eopkg = Command::new("eopkg").arg("list-installed").output().context(Pkgcount)?;
+    let eopkg = Command::new("eopkg")
+        .arg("list-installed")
+        .output()
+        .context(Pkgcount)?;
     let pkgs = bytecount::count(&eopkg.stdout, b'\n');
     let pkg = format!("{}", pkgs);
     Ok(pkg)


### PR DESCRIPTION
Added support for BSD (pkg), Solus (eopkg), and OpenSUSE (rpm).

I feel like there is a much more efficient way to do this that a bunch of if/else if statements for the output. I feel like we could probably also combine the package count functions into a single one somehow, or at least make it more compact. But there's got to be much more efficient ways of doing this.