### PR TITLE
Add CPU information field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ JOBS  ?= 1
 
 # flags
 DFLAGS = --color always -j$(JOBS)
-RFLAGS = ${DFLAGS} --release -j$(JOBS)
+RFLAGS = ${DFLAGS} --release
 
 # run args
 ifeq (run,$(firstword $(MAKECMDGOALS)))

--- a/specs/2.md
+++ b/specs/2.md
@@ -128,7 +128,7 @@ Model		: Raspberry Pi Zero W Rev 1.1
 where `Hardware` corresponds to the CPU model and `processor` is the number of logical cores minus one.
 
 Then, the file `/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq` is read, which contains the maximum frequency
-of the CPU in kHz. This value can then be parsed into a `usize` and simply divided by `1000` to get
+of the CPU in Hz. This value can then be parsed into a `usize` and simply divided by `1000000` to get
 the maximum frequency in GHz.
 
 ### Memory Information

--- a/specs/2.md
+++ b/specs/2.md
@@ -127,7 +127,7 @@ Model		: Raspberry Pi Zero W Rev 1.1
 
 where `Hardware` corresponds to the CPU model and `processor` is the number of logical cores minus one.
 
-Then, the file `/sys/devices/system/cpu/cpu0/cpufreq` is read, which contains the maximum frequency
+Then, the file `/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq` is read, which contains the maximum frequency
 of the CPU in kHz. This value can then be parsed into a `usize` and simply divided by `1000` to get
 the maximum frequency in GHz.
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -31,7 +31,7 @@ impl CPUInfo {
 
         // frequency
         self.freq = (fs::read_to_string("/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq")?
-            .parse::<usize>().unwrap()) / 1000;
+            .trim_end().parse::<usize>().unwrap()) / 1000000;
 
         Ok(())
     }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -19,27 +19,19 @@ impl CPUInfo {
     // retrieve model, cores, and frequency
     pub fn get(&mut self) -> Result<(), std::io::Error> {
         // model and number of cores
-        if !fs::metadata("/proc/cpuinfo").is_ok() {
-            return Err(());
-        }
-
         let cpuinfos = fs::read_to_string("/proc/cpuinfo")?;
         for line in cpuinfos.split("\n") {
             let cpuinfo = line.split(":").map(|i| i.trim()).collect::<Vec<&str>>();
             match cpuinfo[0] {
                 "Hardware" => self.model = cpuinfo[1].to_string(),
-                "processor" => self.cores = cpuinfo[1].parse::<usize>()? + 1,
+                "processor" => self.cores = cpuinfo[1].parse::<usize>().unwrap() + 1,
                 _ => (),
             }
         }
 
         // frequency
-        if !fs::metadata("/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq").is_ok() {
-            return Err(());
-        }
-
         self.freq = (fs::read_to_string("/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq")?
-            .parse::<usize>()?) / 1000;
+            .parse::<usize>().unwrap()) / 1000;
 
         Ok(())
     }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,0 +1,9 @@
+pub struct CPUInfo {
+    model: String,
+    cores: usize,
+    freq:  usize,
+}
+
+impl CPUInfo {
+
+}

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,9 +1,46 @@
+use std::fs;
+use std::result::Result;
+
 pub struct CPUInfo {
-    model: String,
-    cores: usize,
-    freq:  usize,
+    pub model: String,
+    pub cores: usize,
+    pub freq:  usize,
 }
 
 impl CPUInfo {
+    pub fn new() -> CPUInfo {
+        CPUInfo {
+            model: String::new(),
+            cores: 0,
+            freq:  0,
+        }
+    }
 
+    // retrieve model, cores, and frequency
+    pub fn get(&mut self) -> Result<(), std::io::Error> {
+        // model and number of cores
+        if !fs::metadata("/proc/cpuinfo").is_ok() {
+            return Err(());
+        }
+
+        let cpuinfos = fs::read_to_string("/proc/cpuinfo")?;
+        for line in cpuinfos.split("\n") {
+            let cpuinfo = line.split(":").map(|i| i.trim()).collect::<Vec<&str>>();
+            match cpuinfo[0] {
+                "Hardware" => self.model = cpuinfo[1].to_string(),
+                "processor" => self.cores = cpuinfo[1].parse::<usize>()? + 1,
+                _ => (),
+            }
+        }
+
+        // frequency
+        if !fs::metadata("/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq").is_ok() {
+            return Err(());
+        }
+
+        self.freq = (fs::read_to_string("/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq")?
+            .parse::<usize>()?) / 1000;
+
+        Ok(())
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -412,7 +412,6 @@ fn main() {
                         .help("Turn all caps off.")
                         .takes_value(false))
                     .arg(Arg::with_name("cpu")
-                         .short("C")
                          .long("cpu")
                          .help("Turn CPU information (model, frequency, and processor count) on.")
                          .takes_value(false))

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,9 @@ use std::path::Path;
 use std::process::Command;
 use std::result;
 
+mod cpu;
+use crate::cpu::*;
+
 #[derive(Debug, Snafu)]
 enum Error {
     #[snafu(display("Could not retrieve device name: {}", source))]
@@ -408,6 +411,11 @@ fn main() {
                         .long("no-caps")
                         .help("Turn all caps off.")
                         .takes_value(false))
+                    .arg(Arg::with_name("cpu")
+                         .short("C")
+                         .long("cpu")
+                         .help("Turn CPU information (model, frequency, and processor count) on.")
+                         .takes_value(false))
                     .arg(Arg::with_name("no-user")
                         .short("U")
                         .long("no-user")
@@ -662,6 +670,18 @@ fn main() {
                         shell.to_string_lossy().as_ref(),
                     );
                 }
+        }
+    }
+    if matches.is_present("cpu") {
+        let mut cpu = CPUInfo::new();
+        match cpu.get() {
+            Ok(()) => if matches.is_present("minimal") {
+                println!("{} ({}) @ {}GHz", cpu.model, cpu.cores, cpu.freq);
+            } else {
+                add_row(&mut table, bold, caps, borders, "CPU", 
+                        &format!("{} ({}) @ {}GHz", cpu.model, cpu.cores, cpu.freq));
+            },
+            Err(e) => error!("{}", e),
         }
     }
     if matches.is_present("ip_address") {


### PR DESCRIPTION
Adds the CPU information field as `--cpu`. This information field does not have a short option.