### PR TITLE
Change version to 2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsfetch"
-version = "1.9.0"
+version = "2.0.0"
 authors = ["Phate6660 <ValleyKnight@protonmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,7 +117,7 @@ fn main() {
     //let args = load_yml!("args.yml");
     //let matches = App::from(args).get_matches();
     let matches = App::new("rsfetch")
-                    .version("{}", env!("CARGO_PKG_VERSION"))
+                    .version("2.0.0")
                     .about("\nAn fetch tool for Linux. Fast (~1ms execution time) and somewhat(?) minimal.\n\nAll options are off by default. \n\nAccepted values for the package manager are \"pacman\", \"apt\", \"xbps\", \"dnf\", \"pkg\", \"eopkg\", \"rpm\", \"apk\", \"pip\", \"portage\", and \"cargo\".")
                     .arg(Arg::with_name("credits")
                         .long("credits")

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,7 +117,7 @@ fn main() {
     //let args = load_yml!("args.yml");
     //let matches = App::from(args).get_matches();
     let matches = App::new("rsfetch")
-                    .version("1.9.0")
+                    .version("2.0.0")
                     .about("\nAn fetch tool for Linux. Fast (~1ms execution time) and somewhat(?) minimal.\n\nAll options are off by default. \n\nAccepted values for the package manager are \"pacman\", \"apt\", \"xbps\", \"dnf\", \"pkg\", \"eopkg\", \"rpm\", \"apk\", \"pip\", \"portage\", and \"cargo\".")
                     .arg(Arg::with_name("credits")
                         .long("credits")

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,7 +117,7 @@ fn main() {
     //let args = load_yml!("args.yml");
     //let matches = App::from(args).get_matches();
     let matches = App::new("rsfetch")
-                    env!("CARGO_PKG_VERSION")
+                    .version("{}", env!("CARGO_PKG_VERSION"))
                     .about("\nAn fetch tool for Linux. Fast (~1ms execution time) and somewhat(?) minimal.\n\nAll options are off by default. \n\nAccepted values for the package manager are \"pacman\", \"apt\", \"xbps\", \"dnf\", \"pkg\", \"eopkg\", \"rpm\", \"apk\", \"pip\", \"portage\", and \"cargo\".")
                     .arg(Arg::with_name("credits")
                         .long("credits")

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,7 +117,7 @@ fn main() {
     //let args = load_yml!("args.yml");
     //let matches = App::from(args).get_matches();
     let matches = App::new("rsfetch")
-                    .version("2.0.0")
+                    env!("CARGO_PKG_VERSION")
                     .about("\nAn fetch tool for Linux. Fast (~1ms execution time) and somewhat(?) minimal.\n\nAll options are off by default. \n\nAccepted values for the package manager are \"pacman\", \"apt\", \"xbps\", \"dnf\", \"pkg\", \"eopkg\", \"rpm\", \"apk\", \"pip\", \"portage\", and \"cargo\".")
                     .arg(Arg::with_name("credits")
                         .long("credits")


### PR DESCRIPTION
It looks like everything in the projects tab is done code-wise. It only makes sense to set the version to 2.0.0 now, but I'm opening a PR just in case you had anything else you wanted to edit. Once this is approved, I'll work on updating crates.io and the prebuilt binary.