### PR TITLE
fix for music info

### DIFF
--- a/src/music.rs
+++ b/src/music.rs
@@ -15,7 +15,7 @@ impl MusicInfo {
     pub fn get(&mut self) -> Result<()> {
         let data = Command::new("mpc")
             .arg("-f")
-            .arg("%artist% - (%date%) %album% - %title%")
+            .arg("%artist% - (%date%) %album% - %title%a")
             .output().context(Mpc)?;
         self.data = String::from_utf8_lossy(&data.stdout)
             .into_owned().split("\n").collect::<Vec<&str>>()[0].to_string();

--- a/src/music.rs
+++ b/src/music.rs
@@ -16,12 +16,9 @@ impl MusicInfo {
         let data = Command::new("mpc")
             .arg("-f")
             .arg("%artist% - (%date%) %album% - %title%")
-            .arg("|")
-            .arg("head")
-            .arg("-n1")
             .output().context(Mpc)?;
         self.data = String::from_utf8_lossy(&data.stdout)
-            .into_owned();
+            .into_owned().split("\n").collect::<Vec<&str>>()[0].to_string();
         self.data.pop();
 
         Ok(())

--- a/src/music.rs
+++ b/src/music.rs
@@ -16,6 +16,9 @@ impl MusicInfo {
         let data = Command::new("mpc")
             .arg("-f")
             .arg("%artist% - (%date%) %album% - %title%")
+            .arg("|")
+            .arg("head")
+            .arg("-n1")
             .output().context(Mpc)?;
         self.data = String::from_utf8_lossy(&data.stdout)
             .into_owned();


### PR DESCRIPTION
I had completely forgotten that `mpc` will output 3 lines like:

```
formatted - music - info
music and playlist status
mpd info
```

Currently, rsfetch will output the music info like this: `formatted - music - info music and playlist status mpd info`

For now, I'll add `| head -n1` as additional arguments to only output the first line (which is what we want).<br>
I don't have the time or resources right now to test out code a bunch of times until I figure it out as I'd be debugging it via `ssh` on a Pi.

Note: This has not been tested, I just quickly threw these args in. Hopefully it works. If not, will fix it later.