### PR TITLE
Replace crates: reqwest with hyper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,6 @@ dirs = "1.0"
 log = "0.4"
 pretty_env_logger = "0.3"
 prettytable-rs = "0.8"
-reqwest = "0.9"
+hyper = "0.13"
+tokio = { version = "0.2", default-features = false, features = ["macros"] }
 snafu = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,6 @@ log = "0.4"
 pretty_env_logger = "0.3"
 prettytable-rs = "0.8"
 hyper = "0.13"
+hyper-tls = "0.4.1"
 tokio = { version = "0.2", default-features = false, features = ["macros"] }
 snafu = "0.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ pub enum Error {
     #[snafu(display("Unable to retrieve USER, SHELL, or EDITOR/VISUAL."))]
     EnvError { source: std::env::VarError },
     #[snafu(display("Unable to retrieve IP address: {}", source))]
-    Reqwest { source: reqwest::Error },
+    Hyper { source: hyper::Error },
     #[snafu(display("Unable to retrieve package count."))]
     Pkgcount { source: std::io::Error },
     #[snafu(display("Unable to retrive mpd information."))]
@@ -114,8 +114,8 @@ fn get_logo_from_file(path: String) -> Result<String> {
     let logo = std::fs::read_to_string(&*path).context(ReadLogo)?;
     Ok(logo)
 }
-
-fn main() {
+#[tokio::main]
+async fn main() {
     pretty_env_logger::init();
 
     // Variables
@@ -463,7 +463,7 @@ fn main() {
 
     if matches.is_present("ip-address") {
         let mut ip = NetworkInfo::new();
-        match ip.get() {
+        match ip.get().await {
             Ok(()) => writer.add("IP ADDRESS", &ip.format()),
             Err(e) => error!("{}", e),
         }

--- a/src/network.rs
+++ b/src/network.rs
@@ -17,11 +17,15 @@ impl NetworkInfo {
         }
     }
 
-    pub fn get(&mut self) -> Result<()> {
-        self.ip_address = reqwest::get("https://ipecho.net/plain")
-            .context(Reqwest)?
-            .text()
-            .context(Reqwest)?;
+    pub async fn get(&mut self) -> Result<()> {
+        let client = hyper::Client::new();
+        let resp = client.get(hyper::Uri::from_static("http://ipecho.net/plain"))
+                    .await
+                    .context(Hyper)?;
+        let buf = hyper::body::to_bytes(resp)
+                    .await
+                    .context(Hyper)?;
+        self.ip_address = std::str::from_utf8(&buf).unwrap().to_string();
         Ok(())
     }
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -18,8 +18,11 @@ impl NetworkInfo {
     }
 
     pub async fn get(&mut self) -> Result<()> {
-        let client = hyper::Client::new();
-        let resp = client.get(hyper::Uri::from_static("http://ipecho.net/plain"))
+        //let client = hyper::Client::new();
+	let https = hyper_tls::HttpsConnector::new();
+	let client = hyper::Client::builder()
+	    .build::<_, hyper::Body>(https);
+        let resp = client.get(hyper::Uri::from_static("https://ipecho.net/plain"))
                     .await
                     .context(Hyper)?;
         let buf = hyper::body::to_bytes(resp)


### PR DESCRIPTION
Since I saw that in the main.rs file you wanted to replace reqwest with a lighter crate I replaced it with hyper. 
Hyper is a lower level library. Reqwest is built on top of hyper.

Although reqwest crate is 0.12 MB and hyper is 0.14 MB (according to crate.io) hyper has less dependencies to download when building and running rsfetch.

On Linux x64 using rustc 1.42.0
`cargo build --release`
rsfetch with reqwest crate: 8.8 MiB (9,208,408 bytes)
rsfetch with hyper crate: 7.2 MiB (7,572,282 bytes)