### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -24,17 +24,17 @@ impl DeviceInfo {
             Ok(c) => self.model = c.trim().to_string(),
             Err(_) => {
                 // fallback to sysctl...
-                let mut model = String::new();
-                Command::new("sysctl")
+                let command = Command::new("sysctl")
                     .arg("-n")
                     .arg("hw.model")
                     .output()
-                    .context(DeviceName)?
-                    .stdout
-                    .iter()
-                    .map(|b| model.push(*b as char))
-                    .collect::<()>();
-                self.model = model.trim().to_string();
+                    .context(DeviceName)?;
+
+                let model = std::str::from_utf8(&command.stdout)
+                    .unwrap()
+                    .replace("\n", "");
+
+                self.model = model.trim().into();
             }
         }
 

--- a/src/distro.rs
+++ b/src/distro.rs
@@ -109,8 +109,7 @@ impl DistroInfo {
             match uname {
                 Ok(out) => {
                     let output = String::from_utf8(out.stdout)
-                        .unwrap()
-                        .replace("\n", "");
+                        .unwrap();
 
                     self.name = output;
                     Ok(())

--- a/src/distro.rs
+++ b/src/distro.rs
@@ -108,13 +108,9 @@ impl DistroInfo {
             let uname = Command::new("uname").arg("-s").output();
             match uname {
                 Ok(out) => {
-                    let mut output = "".to_owned();
-                    out.stdout
-                        .iter()
-                        .map(|b| {
-                            output.push(*b as char);
-                        })
-                        .collect::<()>();
+                    let output = String::from_utf8(out.stdout)
+                        .unwrap()
+                        .replace("\n", "");
 
                     self.name = output;
                     Ok(())

--- a/src/env.rs
+++ b/src/env.rs
@@ -28,13 +28,9 @@ impl EnvInfo {
                 let command = Command::new("id").arg("-un").output();
                 match command {
                     Ok(o) => {
-                        let mut user = String::new();
-                        o.stdout
-                            .iter()
-                            .map(|b| {
-                                user.push(*b as char);
-                            })
-                            .collect::<()>();
+                        let user = String::from_utf8(o.stdout)
+                            .unwrap()
+                            .replace("\n", "");
 
                         if user != "" {
                             self.user = user;

--- a/src/hostname.rs
+++ b/src/hostname.rs
@@ -24,8 +24,7 @@ impl Hostname {
                 .context(ReadHostname)?;
 
             let hostname = String::from_utf8(command.stdout)
-                .unwrap()
-                .replace("\n", "");
+                .unwrap();
 
             self.name = hostname;
         }

--- a/src/hostname.rs
+++ b/src/hostname.rs
@@ -19,15 +19,16 @@ impl Hostname {
             self.name = f.trim().to_string();
         } else {
             // fallback to `hostname` command
-            let mut hostname = String::new();
-            Command::new("hostname")
+            let command = Command::new("hostname")
                 .output()
-                .context(ReadHostname)?
-                .stdout
-                .iter()
-                .map(|b| hostname.push(*b as char))
-                .collect::<()>();
-            self.name = hostname.trim().to_string();
+                .context(ReadHostname)?;
+
+            let hostname = String::from_utf8(command.stdout)
+                .unwrap()
+                .replace("\n", "")
+                .into();
+
+            self.name = hostname;
         }
 
         Ok(())

--- a/src/hostname.rs
+++ b/src/hostname.rs
@@ -25,8 +25,7 @@ impl Hostname {
 
             let hostname = String::from_utf8(command.stdout)
                 .unwrap()
-                .replace("\n", "")
-                .into();
+                .replace("\n", "");
 
             self.name = hostname;
         }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -25,8 +25,7 @@ impl KernelInfo {
                 .context(KernelVersion)?;
 
             let output = std::str::from_utf8(&command.stdout)
-                .unwrap()
-                .replace("\n", "");
+                .unwrap();
 
             self.version = output.trim().into();
         }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -19,16 +19,16 @@ impl KernelInfo {
             let f = fs::read_to_string(path).context(KernelVersion)?;
             self.version = f.trim().to_string();
         } else {
-            let mut output: String = String::new();
-            Command::new("uname")
+            let command = Command::new("uname")
                 .arg("-r")
                 .output()
-                .context(KernelVersion)?
-                .stdout
-                .iter()
-                .map(|b| output.push(*b as char))
-                .collect::<()>();
-            self.version = output.trim().to_string();
+                .context(KernelVersion)?;
+
+            let output = std::str::from_utf8(&command.stdout)
+                .unwrap()
+                .replace("\n", "");
+
+            self.version = output.trim().into();
         }
 
         Ok(())

--- a/src/output.rs
+++ b/src/output.rs
@@ -149,15 +149,13 @@ impl OutputHelper {
 
             let stuff = self.data.clone();
 
-            stuff
-                .iter()
-                .map(|i| {
-                    let key = &i.key;
-                    if key.len() > key_width {
-                        key_width = key.len();
-                    }
-                })
-                .collect::<()>();
+            for i in &stuff {
+                let key = &i.key;
+                if key.len() > key_width {
+                    key_width = key.len();
+                }
+            }
+
             key_width += 2;
 
             let mut printed = 0;

--- a/src/output.rs
+++ b/src/output.rs
@@ -109,7 +109,7 @@ impl OutputHelper {
             // convert self.data to table, then print
             for thing in self.data.clone() {
                 let mut key = thing.key.clone();
-                let val = thing.val.clone().replace("\n", "");
+                let val = thing.val.clone();
 
                 if !self.options.caps {
                     key = key.to_lowercase();
@@ -162,7 +162,7 @@ impl OutputHelper {
             for c in 0..stuff.len() {
                 let thing = stuff[c].clone();
                 let mut key = thing.key;
-                let val = thing.val.replace("\n", "");
+                let val = thing.val;
 
                 if !self.options.caps {
                     key = key.to_lowercase();

--- a/src/pkgs.rs
+++ b/src/pkgs.rs
@@ -96,16 +96,13 @@ impl PkgInfo {
 
             // count lines in stdout
             let mut count: usize = 0;
-            output
-                .stdout
-                .iter()
-                .map(|b| {
-                    if (*b as usize) == 10 {
-                        count += 1;
-                    }
-                })
-                .collect::<()>();
 
+            for i in &output.stdout {
+                if (*i as usize) == 10 {
+                    count += 1;
+                }
+            }
+            
             self.count += count;
         }
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -18,10 +18,10 @@ fn get_ppid(id: u32) -> Option<u32> {
             let info = i.split(':').collect::<Vec<&str>>();
             if info.len() > 1 {
                 let key = info[0].trim();
-                let val = info[1].trim().replace("\n", "");
+                let val = info[1].trim();
 
                 if key == "PPid" {
-                    ppid_str = val;
+                    ppid_str = val.into();
                 }
             }
         });

--- a/src/uptime.rs
+++ b/src/uptime.rs
@@ -31,16 +31,16 @@ impl UptimeInfo {
             // convert proc_uptime (a string) to usize
             seconds = proc_uptime.parse::<u64>().unwrap();
         } else {
-            let mut sysctl: String = String::new();
-            Command::new("sysctl")
+            let command = Command::new("sysctl")
                 .arg("-n")
                 .arg("kern.boottime")
                 .output()
-                .context(Uptime)?
-                .stdout
-                .iter()
-                .map(|b| sysctl.push(*b as char))
-                .collect::<()>();
+                .context(Uptime)?;
+
+            let sysctl = String::from_utf8(command.stdout)
+                .unwrap()
+                .replace("\n", "");
+
             let boottime: u64 = sysctl.split(',').collect::<Vec<&str>>()[0]
                 .split("sec =")
                 .collect::<Vec<&str>>()[1]


### PR DESCRIPTION
This fixes the warnings when compiling the project. #88 

Also it's much easier to read than chaining three functions .iter().map().collect()

Some are String::from_utf8() and others std::str::from_utf8() because functions such as .trim() would return a &str and then you'd have to transform it back to String using .into() or to_string(). So it would be String -> &str -> String.

I did remove some unnecessary .replace() functions. The output is the same for rsfetch, neofetch and minimal style but I couldn't test the output for BSDs systems because it uses sysctl.