### PR TITLE
Rewrite Rsfetch output without prettytable-rs crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ clap = "^2.33"
 dirs = "1.0"
 log = "0.4"
 pretty_env_logger = "0.3"
-prettytable-rs = "0.8"
 hyper = "0.13"
 hyper-tls = "0.4.1"
 tokio = { version = "0.2", default-features = false, features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsfetch"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["Phate6660 <ValleyKnight@protonmail.com>"]
 edition = "2018"
 description = "A neofetch-esque tool written in Rust."

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,7 +119,7 @@ async fn main() {
     //let args = load_yml!("args.yml");
     //let matches = App::from(args).get_matches();
     let matches = App::new("rsfetch")
-                    .version("2.0.0")
+                    .version("2.0.2")
                     .about("\nAn info fetch tool for Linux. Fast (~1ms execution time) and somewhat(?) minimal.\n\nAll options are off by default. \n\nAccepted values for the package manager are \"pacman\", \"apt\", \"xbps\", \"dnf\", \"pkg\", \"eopkg\", \"rpm\", \"apk\", \"pip\", \"portage\", and \"cargo\".")
                     .arg(Arg::with_name("credits")
                         .long("credits")

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,7 +306,7 @@ async fn main() {
     }
 
     if matches.is_present("logo") {
-        print!("\n"); // print blank line before output.
+        println!(); // print blank line before output.
     }
 
     let mut writer = OutputHelper::new(opts);


### PR DESCRIPTION
Since prettytable-rs was only used for Rsfetch style then I thought It wasn't really needed, plus rsfetch is supposed to be a fast and minimal fetch program 😀

The output is still the same except for the 'no borders' option. `Borders != Corners` current rsfetch 'no border' flag just removes the corners, so with my PR it actually removes borders (and corners of course). It still has the option to set your own corner char.

```
     Running `target/debug/rsfetch -dklstuUwB`

 ┬─┐┌─┐┌─┐┌─┐┌┬┐┌─┐┬ ┬
 ├┬┘└─┐├┤ ├┤  │ │  ├─┤
 ┴└─└─┘└  └─┘ ┴ └─┘┴ ┴
 USER       =   tomas 
 OS         =   Ubuntu 19.10 
 UPTIME     =   3h 21m  
 KERNEL     =   5.3.0-45-generic 
 DE         =   XFCE 
 SHELL      =   bash 
 TERMINAL   =   xfce4-terminal
```

I think it can still be improved, I'm sure some things done inside the output function could be made into smaller functions to reduce complexity.

And of course because I removed prettytable-rs crate the final binary is a bit smaller and a bit faster at least according to [hyperfine](https://github.com/sharkdp/hyperfine).

I look forward to receiving feedback.