### PR TITLE
Add CPU temperature to CPU field

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -93,24 +93,29 @@ impl CPUInfo {
                 .output()
                 .context(BSDCPUErr)?;
 
-            let mut temp = String::from_utf8(cpu_temp.stdout)
-                .unwrap()
-                .replace("\n", "")
-                .replace("C", "")
-                .trim()
-                .parse::<f64>()
-                .unwrap();
+            if !cpu_temp.stdout.is_empty() {
+                let mut temp = String::from_utf8(cpu_temp.stdout)
+                    .unwrap()
+                    .replace("\n", "")
+                    .replace("C", "")
+                    .trim()
+                    .parse::<f64>()
+                    .unwrap();
 
-            let temp_scale = if self.options.farenheit {
-                temp = (temp * (9.0 / 5.0)) + 32.0;
-                "F"
-            } else {
-                "C"
-            };
+                let temp_scale = if self.options.farenheit {
+                    temp = (temp * (9.0 / 5.0)) + 32.0;
+                    "F"
+                } else {
+                    "C"
+                };
+
+                self.temp = format!("{}°{}", temp, temp_scale);
+            }
+
 
             self.cores = cores.parse::<usize>().context(BSDCPUParseErr)?;
             self.freq = speed.parse::<f64>().context(CPUFreqParseErr)? / 1000_f64;
-            self.temp = format!("{}°{}", temp, temp_scale);
+
             return Ok(());
         }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -122,7 +122,6 @@ impl CPUInfo {
                 .trim_end()
                 .parse::<f64>()
                 .unwrap()/1000.0;
-            println!("TEMP: {}", temp);
             let temp_scale = if self.options.farenheit {
                 temp = (temp * (9.0 / 5.0)) + 32.0;
                 "F"

--- a/src/device.rs
+++ b/src/device.rs
@@ -21,7 +21,7 @@ impl DeviceInfo {
 
         let f = fs::read_to_string(path);
         match f {
-            Ok(c) => self.model = c.trim().to_string(),
+            Ok(c) => self.model = c.trim().trim_matches(char::from(0)).to_string(),
             Err(_) => {
                 // fallback to sysctl...
                 let command = Command::new("sysctl")

--- a/src/main.rs
+++ b/src/main.rs
@@ -266,6 +266,8 @@ async fn main() {
     let caps = !matches.is_present("no-caps");
     let borders = !matches.is_present("no-borders");
 
+    let temp = matches.is_present("farenheit");
+
     // For the options that require bools or other input.
     let corners = matches.value_of("corners").unwrap_or("■");
     let music = matches.value_of("music").unwrap_or("");
@@ -297,14 +299,6 @@ async fn main() {
         use_borders: borders,
         borders: corner,
     };
-
-    let temp: bool;
-
-    if matches.is_present("farenheit"){
-        temp = true;
-    } else {
-        temp = false;
-    }
 
     let cpu_opts = CPUOptions {
         farenheit: temp

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,6 +140,10 @@ async fn main() {
                          .long("cpu")
                          .short("P")
                          .help("Turn CPU information on."))
+                    .arg(Arg::with_name("farenheit")
+                        .long("farenheit")
+                        .short("f")
+                        .help("Display temperature in farenheit instead of celcius."))
                     .arg(Arg::with_name("terminal")
                         .long("terminal")
                         .short("t")
@@ -292,6 +296,18 @@ async fn main() {
         bold,
         use_borders: borders,
         borders: corner,
+    };
+
+    let temp: bool;
+
+    if matches.is_present("farenheit"){
+        temp = true;
+    } else {
+        temp = false;
+    }
+
+    let cpu_opts = CPUOptions {
+        farenheit: temp
     };
 
     //let format;
@@ -451,7 +467,7 @@ async fn main() {
     }
 
     if matches.is_present("cpu") {
-        let mut cpu = CPUInfo::new();
+        let mut cpu = CPUInfo::new(cpu_opts);
         match cpu.get(&os) {
             Ok(()) => writer.add("CPU", &cpu.format()),
             Err(e) => error!("{}", e),


### PR DESCRIPTION
I added the temperature to the CPU field because I saw issue #74 . 
You can pass the flag -f or --farenheit.

I couldn't test completely for BSD systems because I was using a virtual machine and it didn't have the temperature field in sysctl. But atleast according to [nixCraft](https://www.cyberciti.biz/faq/freebsd-determine-processor-cpu-temperature-command/) it should be those fields. If the fields don't exist or are empty then it should just skip it.

```
target/debug/rsfetch -PdhHklrstuU
 ┬─┐┌─┐┌─┐┌─┐┌┬┐┌─┐┬ ┬
 ├┬┘└─┐├┤ ├┤  │ │  ├─┤
 ┴└─└─┘└  └─┘ ┴ └─┘┴ ┴
■──────────────────────────────────────────────────■
│ USER       =   pi                                │
│ HOSTNAME   =   raspberrypi                       │
│ OS         =   Raspbian GNU/Linux 9 (stretch)    │
│ HOST       =   Raspberry Pi 3 Model B Rev 1.2    │
│ UPTIME     =   1d 8h 38m                         │
│ KERNEL     =   4.19.66-v7+                       │
│ SHELL      =   bash                              │
│ TERMINAL   =   sshd                              │
│ CPU        =   BCM2835 (4) @ 1.200GHz (56.4°C)   │
│ MEMORY     =   85MiB / 926MiB                    │
■──────────────────────────────────────────────────■
```
```
target/debug/rsfetch -PdhHklrstuUf
 ┬─┐┌─┐┌─┐┌─┐┌┬┐┌─┐┬ ┬
 ├┬┘└─┐├┤ ├┤  │ │  ├─┤
 ┴└─└─┘└  └─┘ ┴ └─┘┴ ┴
■───────────────────────────────────────────────────■
│ USER       =   pi                                 │
│ HOSTNAME   =   raspberrypi                        │
│ OS         =   Raspbian GNU/Linux 9 (stretch)     │
│ HOST       =   Raspberry Pi 3 Model B Rev 1.2     │
│ UPTIME     =   1d 8h 38m                          │
│ KERNEL     =   4.19.66-v7+                        │
│ SHELL      =   bash                               │
│ TERMINAL   =   sshd                               │
│ CPU        =   BCM2835 (4) @ 1.200GHz (124.8°F)   │
│ MEMORY     =   85MiB / 926MiB                     │
■───────────────────────────────────────────────────■
```
NOTE: There is a commit to fix raspberry pi 3 output because getting the `HOST` value had a null char at the end \u{0} which made the border not align with the others `│`.

PS: I tried the ascii art from issue #73 with my raspberry pi 3 and the output is perfectly fine.
PS2: Wouldn't it be better to use [Conditional compilation](https://doc.rust-lang.org/reference/conditional-compilation.html)? CPU information seems to be completely different for Linux and BSD systems.